### PR TITLE
add filter to $attachment_ids to be able to include more media ids

### DIFF
--- a/api/v1/controllers/Posts.php
+++ b/api/v1/controllers/Posts.php
@@ -298,6 +298,8 @@ class Posts {
 			if ( $thumbnail_id = get_post_thumbnail_id( $post->ID ) ) {
 				$attachment_ids[] = $meta['featured_image'] = ( int ) $thumbnail_id;
 			}
+			
+			$attachment_ids = apply_filters_ref_array( 'thermal_attachment_ids', array( $attachment_ids, &$post ) );
 
 			$attachment_ids = array_unique( $attachment_ids );
 			foreach ( $attachment_ids as $attachment_id ) {


### PR DESCRIPTION
This way you can add things like these:

```
add_filter( 'thermal_attachment_ids', function($attachment_ids, &$post ) {
    //get media in ACF images (look for 'imageid') 
    $custom_fields = get_post_custom( $post->ID );
    foreach ( $custom_fields as $field_key => $field_values ) {
        foreach ( $field_values as $key => $value ) {
            if ( ( strpos($field_key, '_') !== 0 ) && ( strpos($field_key,'imageid') !== false ) ) {  
                array_push($attachment_ids, (int)$value);
            }
        }
    }
    // if it's an attachment, add its own ID so media gets populated
    if ( $post->post_type === "attachment" ) {
        array_push( $attachment_ids, $post->ID );
    }
    return $attachment_ids; }, 10, 2);
```
