### PR TITLE
Make dispatch_api hookable

### DIFF
--- a/api/v1/controllers/Posts.php
+++ b/api/v1/controllers/Posts.php
@@ -105,6 +105,7 @@ class Posts {
 			'post_status' => array( '\\Voce\\Thermal\\v1\\toArray' ),
 			'post_parent__in' => array( '\\Voce\\Thermal\\v1\\toArray', '\\Voce\\Thermal\\v1\\applyInt' ),
 			'include_found' => array( '\\Voce\\Thermal\\v1\\toBool' ),
+			'ignore_sticky_posts' => array( '\\Voce\\Thermal\\v1\\toBool' ),
 		);
 		//strip any nonsafe args
 		$request_args = array_intersect_key( $request_args, $request_filters );
@@ -272,6 +273,7 @@ class Posts {
 			'excerpt' => $post->post_excerpt,
 			'content' => $post->post_content,
 			'author' => $post->post_author,
+			'is_sticky' => is_sticky(),
 		);
 
 		//add extended data for 'read'

--- a/dispatcher.php
+++ b/dispatcher.php
@@ -39,14 +39,19 @@ class API_Dispatcher {
 		//if requested url starts with api_base_url()
 		if ( false !== strpos( $_SERVER['REQUEST_URI'], get_api_base() ) ) {
 			require_once( 'api/v1/API.php' );
-
-			add_action( 'wp_loaded', array( $this, 'dispatch_api' ) );
+			
+			// Add API dispatch action
+			add_action('dispatch_api', array( $this, 'dispatch_api' ) );
+			
+			add_action( 'wp_loaded', function(){
+				do_action('dispatch_api');
+			});
 		}
 	}
 
 	public function dispatch_api() {
-		require_once( 'lib/jsonp/jsonp.php' );
 
+		require_once( 'lib/jsonp/jsonp.php' );
 
 		\Slim\Slim::registerAutoloader();
 
@@ -58,5 +63,4 @@ class API_Dispatcher {
 
 		exit;
 	}
-
 }


### PR DESCRIPTION
* Make dispatch_api hookable event
* Allow API to ignore_sticky_posts

Edit: Whoops - Was meaning to submit this pull to our own master. That said, I was planning on putting an upstream pull in anyway (although not necessarily combined), so will leave for now. 

For some additional context, this pull contains two primary changes:

* The ability to filter on "ignore_sticky_posts" + to show a posts sticky status in the API.
* Making "dispatch_api" an action, so that additional hooks can be configured against it. In our case this is to add some additional authentication logic whenever the API is invoked.

Do both / either of these changes sound like something you'd be interested in pulling in upstream? If so, I'd be happy to split them in the separate branches if preferred.